### PR TITLE
Add clipboard and UI modules

### DIFF
--- a/honeycomb-simple.html
+++ b/honeycomb-simple.html
@@ -131,86 +131,19 @@
     </div>
     
     <aside class="clipboard">
-      <h2>クリップボード</h2>
+      <div class="project-prompt-container">
+        <div class="project-prompt-header">プロジェクトプロンプト</div>
+        <textarea id="project-prompt-textarea"></textarea>
+      </div>
+      <div class="clipboard-separator"></div>
+      <div class="clipboard-content"></div>
     </aside>
   </main>
-  
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      console.log('DOMContentLoaded イベントが発生しました');
-      
-      // SVG要素を取得
-      const svg = document.getElementById('honeycomb-container');
-      console.log('SVG要素:', svg);
-      
-      if (!svg) {
-        console.error('SVG要素が見つかりません');
-        return;
-      }
-      
-      // SVGの内容をクリア
-      svg.innerHTML = '';
-      
-      // テスト用に単純な図形を追加
-      const testCircle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-      testCircle.setAttribute('cx', 400);
-      testCircle.setAttribute('cy', 300);
-      testCircle.setAttribute('r', 50);
-      testCircle.setAttribute('fill', 'red');
-      svg.appendChild(testCircle);
-      console.log('テスト用の円を追加しました');
-      
-      // 5x5のグリッドを描画
-      const rows = 5;
-      const cols = 5;
-      
-      // グリッドの中心位置
-      const centerX = 400;
-      const centerY = 300;
-      
-      // グリッドの左上の位置を計算
-      const startX = centerX - (cols * 100) / 2;
-      const startY = centerY - (rows * 100) / 2;
-      
-      // シンプルなグリッドを描画
-      for (let row = 0; row < rows; row++) {
-        for (let col = 0; col < cols; col++) {
-          // 六角形の中心座標を計算
-          const x = startX + col * 100;
-          const y = startY + row * 100 + (col % 2 === 0 ? 0 : 50);
-          
-          // シンプルな六角形を描画
-          const hex = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
-          const points = [];
-          const radius = 40;
-          
-          for (let i = 0; i < 6; i++) {
-            const angle = 2 * Math.PI / 6 * i + Math.PI/6;
-            const pointX = x + radius * Math.cos(angle);
-            const pointY = y + radius * Math.sin(angle);
-            points.push(`${pointX},${pointY}`);
-          }
-          
-          hex.setAttribute('points', points.join(' '));
-          hex.setAttribute('fill', '#555555');
-          hex.setAttribute('stroke', '#ffffff');
-          hex.setAttribute('stroke-width', '2');
-          
-          // ノードIDを表示するテキスト
-          const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-          text.setAttribute('x', x);
-          text.setAttribute('y', y);
-          text.setAttribute('text-anchor', 'middle');
-          text.setAttribute('dominant-baseline', 'middle');
-          text.setAttribute('fill', '#ffffff');
-          text.setAttribute('font-size', '12px');
-          text.textContent = `${row}-${col}`;
-          
-          svg.appendChild(hex);
-          svg.appendChild(text);
-        }
-      }
-    });
-  </script>
+
+  <script src="js/honeycomb-data.js"></script>
+  <script src="js/honeycomb-storage.js"></script>
+  <script src="js/honeycomb-ui.js"></script>
+  <script src="js/honeycomb-clipboard.js"></script>
+  <script src="js/honeycomb-core.js"></script>
 </body>
 </html>

--- a/js/honeycomb-clipboard.js
+++ b/js/honeycomb-clipboard.js
@@ -1,0 +1,59 @@
+// Clipboard UI utilities
+window.HoneycombApp = window.HoneycombApp || {};
+const HoneycombApp = window.HoneycombApp;
+
+// Add clipboard entry element
+HoneycombApp.addClipboardEntry = function(type, content, timestamp, nodeId) {
+  const container = document.querySelector('.clipboard-content');
+  if (!container) return null;
+
+  const entry = document.createElement('div');
+  entry.className = 'clipboard-entry';
+  if (nodeId) entry.setAttribute('data-node-id', nodeId);
+
+  const header = document.createElement('div');
+  header.className = 'clipboard-entry-header';
+
+  const typeSpan = document.createElement('span');
+  typeSpan.className = 'entry-type';
+  typeSpan.textContent = type || '';
+
+  const timeSpan = document.createElement('span');
+  timeSpan.className = 'entry-timestamp';
+  timeSpan.textContent = timestamp || new Date().toISOString();
+
+  header.appendChild(typeSpan);
+  header.appendChild(timeSpan);
+
+  const textarea = document.createElement('textarea');
+  textarea.className = 'clipboard-textarea';
+  textarea.value = content || '';
+
+  const buttonGroup = document.createElement('div');
+  buttonGroup.className = 'button-group';
+
+  const copyBtn = document.createElement('button');
+  copyBtn.className = 'copy-button';
+  copyBtn.textContent = '⧉';
+  copyBtn.addEventListener('click', () => {
+    textarea.select();
+    try {
+      document.execCommand('copy');
+    } catch (e) {}
+  });
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.className = 'delete-button';
+  deleteBtn.textContent = '×';
+  deleteBtn.addEventListener('click', () => entry.remove());
+
+  buttonGroup.appendChild(copyBtn);
+  buttonGroup.appendChild(deleteBtn);
+
+  entry.appendChild(header);
+  entry.appendChild(textarea);
+  entry.appendChild(buttonGroup);
+
+  container.appendChild(entry);
+  return entry;
+};

--- a/js/honeycomb-ui.js
+++ b/js/honeycomb-ui.js
@@ -1,0 +1,87 @@
+// UI related functionality for Honeycomb grid
+window.HoneycombApp = window.HoneycombApp || {};
+const HoneycombApp = window.HoneycombApp;
+
+// Draw hexagonal grid and populate nodeData
+HoneycombApp.drawGrid = function() {
+  const svg = document.getElementById('honeycomb-container');
+  if (!svg) return;
+
+  svg.innerHTML = '';
+  const width = svg.clientWidth || parseInt(svg.getAttribute('width'), 10);
+  const height = svg.clientHeight || parseInt(svg.getAttribute('height'), 10);
+
+  const radius = HoneycombApp.hexRadius || 40;
+  const hexHeight = HoneycombApp.hexHeight || radius * Math.sqrt(3);
+  const hexWidth = HoneycombApp.hexWidth || radius * 2;
+  const spacingX = HoneycombApp.hexSpacingX || hexWidth * 0.75;
+  const spacingY = HoneycombApp.hexSpacingY || hexHeight;
+
+  const cols = Math.max(1, Math.floor(width / spacingX));
+  const rows = Math.max(1, Math.floor(height / spacingY));
+
+  const startX = (width - (cols - 1) * spacingX - hexWidth) / 2 + radius;
+  const startY = (height - (rows - 1) * spacingY - hexHeight) / 2 + radius;
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const centerX = startX + c * spacingX + (r % 2 ? spacingX / 2 : 0);
+      const centerY = startY + r * spacingY;
+      const nodeId = `${r}-${c}`;
+      HoneycombApp.createNode(nodeId, r, c, centerX, centerY);
+
+      const hex = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+      const points = [];
+      for (let i = 0; i < 6; i++) {
+        const angle = Math.PI / 3 * i + Math.PI / 6;
+        points.push([
+          centerX + radius * Math.cos(angle),
+          centerY + radius * Math.sin(angle)
+        ].join(','));
+      }
+      hex.setAttribute('points', points.join(' '));
+      hex.setAttribute('fill', HoneycombApp.defaultTaskType.color);
+      hex.setAttribute('stroke', '#ffffff');
+      hex.setAttribute('stroke-width', '2');
+      hex.dataset.nodeId = nodeId;
+
+      const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      text.setAttribute('x', centerX);
+      text.setAttribute('y', centerY);
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('dominant-baseline', 'middle');
+      text.setAttribute('fill', '#ffffff');
+      text.setAttribute('font-size', '10px');
+      text.textContent = nodeId;
+
+      svg.appendChild(hex);
+      svg.appendChild(text);
+    }
+  }
+};
+
+// Set up basic UI listeners
+HoneycombApp.setupAllUIListeners = function() {
+  const svg = document.getElementById('honeycomb-container');
+  if (!svg) return;
+
+  svg.addEventListener('click', event => {
+    if (event.target.tagName === 'polygon') {
+      const nodeId = event.target.dataset.nodeId;
+      HoneycombApp.selectedNodeId = nodeId;
+      console.log('Selected node:', nodeId);
+    }
+  });
+
+  const saveBtn = document.getElementById('save-button');
+  if (saveBtn) saveBtn.addEventListener('click', HoneycombApp.saveWorkflow);
+  const loadBtn = document.getElementById('load-button');
+  if (loadBtn) loadBtn.addEventListener('click', HoneycombApp.loadWorkflow);
+  const resetBtn = document.getElementById('reset-button');
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      HoneycombApp.resetAllData();
+      HoneycombApp.drawGrid();
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add Honeycomb UI helpers with drawGrid and listener setup
- implement clipboard entry creation
- load new JS modules in simple demo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f23de9fc8328bc128b77b92fddb5